### PR TITLE
Add option to allow content to be shown on main page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ pygmentsUseClasses=true
   microBlogSection = "posts"
   displayMicroBlog = false
   displayRecent = true
+  displayHomeContent = false
   recentMax = 4
   mail = "mail@example.com"
   phone = "8888888888"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,7 @@
 {{define "main"}}
+    {{if .Site.Params.displayHomeContent}}
+        {{.Content}}
+    {{end}}
     {{if ne .Site.Params.displayRecent false}}
     <div class="section"> 
         <div class="section-title">recent</div> 


### PR DESCRIPTION
Hi, I've made a change to the theme to allow it to optionally show the content from `_index.md` on the home page as I wanted to personalise it a little.

This is how it looks in my local dev env:
![image](https://user-images.githubusercontent.com/26511173/79992243-21d36e80-84ab-11ea-8078-9767b9b0552f.png)
